### PR TITLE
Use consistent naming scheme for python subdir in LIBDIR

### DIFF
--- a/boost-install.jam
+++ b/boost-install.jam
@@ -416,7 +416,7 @@ local rule tag ( name : type ? : property-set )
 
     if $(python)
     {
-        r = $(r:B=$(r:B)-py$(python)) ;
+        r = $(r:B=$(r:B)-python$(python)) ;
     }
 
     .debug "  result=" $(r) ;


### PR DESCRIPTION
Using `$LIBDIR/boost-pythonX.Y` is preferable to `$LIBDIR/boost-pyX.Y` as boost uses `python` as a consistent prefix/suffix for python specific libraries.
@pdimov 