### PR TITLE
Fix Boost_USE_MULTITHREADED & Boost_USE_DEBUG_RUNTIME logic error

### DIFF
--- a/boost-install.jam
+++ b/boost-install.jam
@@ -258,7 +258,7 @@ rule generate-cmake-variant- ( target : sources * : properties * )
     {
         print.text
 
-            "if(Boost_USE_DEBUG_RUNTIME)"
+            "if(\"${Boost_USE_DEBUG_RUNTIME}\" STREQUAL \"\" OR Boost_USE_DEBUG_RUNTIME)"
             "  _BOOST_SKIPPED(\"$(fname)\" \"release runtime, Boost_USE_DEBUG_RUNTIME=${Boost_USE_DEBUG_RUNTIME}\")"
             "  return()"
             "endif()"
@@ -283,7 +283,7 @@ rule generate-cmake-variant- ( target : sources * : properties * )
     {
         print.text
 
-            "if(Boost_USE_MULTITHREADED)"
+            "if(\"${Boost_USE_MULTITHREADED}\" STREQUAL \"\" OR Boost_USE_MULTITHREADED)"
             "  _BOOST_SKIPPED(\"$(fname)\" \"single-threaded, Boost_USE_MULTITHREADED=${Boost_USE_MULTITHREADED}\")"
             "  return()"
             "endif()"


### PR DESCRIPTION
If Boost_USE_MULTITHREADED or Boost_USE_DEBUG_RUNTIME are not defined, they are currently evaluated by Boost's scripts as if they are _neither_ ON and OFF. This commit fixes it so it correctly defaults to ON.

To explain more fully, before this change the checks were as follows:

* If Boost_USE_MULTITHREADED is defined (not empty string) AND is evaluates to false/OFF:
  - skip multithreaded.
* If Boost_USE_MULTITHREADED evaluates to true/ON:
  - skip single threaded

However if Boost_USE_MULTITHREADED is not defined, neither condition is satisfied so neither is skipped. It doesn't satisify the first part of the first condition and it doesn't pass the second condition because a not defined variable isn't truthy.

The checks could have also been done by using `DEFINED` and `NOT DEFINED` but I kept it as `STREQUAL` for consistency with the rest of the script.