### PR TITLE
Resolve symlinks in _BOOST_CMAKEDIR

### DIFF
--- a/boost-install.jam
+++ b/boost-install.jam
@@ -615,7 +615,7 @@ rule generate-cmake-config- ( target : sources * : properties * )
         ""
         "# Compute the include and library directories relative to this file."
         ""
-        "get_filename_component(_BOOST_CMAKEDIR \"${CMAKE_CURRENT_LIST_DIR}/../\" ABSOLUTE)"
+        "get_filename_component(_BOOST_CMAKEDIR \"${CMAKE_CURRENT_LIST_DIR}/../\" REALPATH)"
         : true ;
 
     if [ path.is-rooted $(cmakedir) ]


### PR DESCRIPTION
Fixes the issue of setting Boost_INCLUDE_DIR to "/include" on systems where
/lib or /lib64 are symlinks to /usr/lib.