### PR TITLE
Improve CMake Windows support with DLLs

### DIFF
--- a/boost-install.jam
+++ b/boost-install.jam
@@ -406,7 +406,11 @@ rule generate-cmake-variant- ( target : sources * : properties * )
 
     if $(link) = shared
     {
-        local dllname = "$(fname:B).dll" ;
+        local prefix = [ type.generated-target-prefix SHARED_LIB : $(ps) ] ;
+        .info "  prefix=" $(prefix) ;
+        local suffix = [ type.generated-target-suffix SHARED_LIB : $(ps) ] ;
+        .info "  suffix=" $(suffix) ;
+        local dllname = [ sequence.join $(prefix) $(fname:BS=) "." $(suffix) ] ;
         .info "  dllname=" $(dllname) ;
 
         print.text

--- a/boost-install.jam
+++ b/boost-install.jam
@@ -401,9 +401,26 @@ rule generate-cmake-variant- ( target : sources * : properties * )
         "    INTERFACE_INCLUDE_DIRECTORIES \"\${_BOOST_INCLUDEDIR}\""
         "    INTERFACE_COMPILE_DEFINITIONS \"BOOST_$(lname:U)_NO_LIB\""
         "  )"
-        "endif()"
         ""
         : true ;
+
+    if $(link) = shared
+    {
+        local dllname = "$(fname:B).dll" ;
+        .info "  dllname=" $(dllname) ;
+
+        print.text
+
+        "  if(WIN32)"
+        "    set_target_properties($(target) PROPERTIES"
+        "      IMPORTED_LOCATION \"${_BOOST_LIBDIR}/$(dllname)\""
+        "    )"
+        "  endif()"
+        ""
+        : true ;
+    }
+
+    print.text "endif()" "" : true ;
 
     print.text "# Target file name: $(fname)" "" : true ;
 


### PR DESCRIPTION
This commit sets the IMPORTED_LOCATION property of the imported target to the .dll.
This allows developers to consume the runtime dependend .dlls via the [$<TARGET_RUNTIME_DLLS:tgt>](https://cmake.org/cmake/help/v3.22/manual/cmake-generator-expressions.7.html#genex:TARGET_RUNTIME_DLLS)
generator expression on windows.

An open question is, wheter or not we should set the [IMPORTED_LOCATION ](https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED_LOCATION.html)for all platforms, not only windows, as this doesn't seem to have negative side-effects. I am no CMake nor b2/jam expert though, so I'd be happy about some feedback. 

Signed-off-by: Michael Lackner <mlackner@student.tugraz.at>