### PR TITLE
Detect clangw toolset when using any clang with the ms-abi

### DIFF
--- a/BoostDetectToolset.cmake
+++ b/BoostDetectToolset.cmake
@@ -28,7 +28,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
 
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
-  if(MSVC)
+  if(MSVC_VERSION)
     set(BOOST_DETECTED_TOOLSET "clangw")
   else()
     set(BOOST_DETECTED_TOOLSET "clang")


### PR DESCRIPTION
When compiling with clang, cmake only sets MSVC when using clang-cl as
it's meant as an indication of cl.exe command line compatibility.

In this case, if one is using clang++ with the ms-abi, cmake
incorrectly takes the else branch here and library detection fails.

If instead we use MSVC_VERSION, which is empty unless a compiler
with _MSC_VER set is being used, then we get the correct behaviour.

https://cmake.org/cmake/help/latest/variable/MSVC.html

https://cmake.org/cmake/help/latest/variable/MSVC_VERSION.html