### PR TITLE
Add helpful error message in case CMAKE_CXX_COMPILER_VERSION is not set

### DIFF
--- a/BoostDetectToolset.cmake
+++ b/BoostDetectToolset.cmake
@@ -2,6 +2,9 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
+if(NOT CMAKE_CXX_COMPILER_VERSION)
+  message(SEND_ERROR "CMAKE_CXX_COMPILER_VERSION is not set!")
+endif()
 string(REGEX MATCHALL "[0-9]+" _BOOST_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION})
 
 list(GET _BOOST_COMPILER_VERSION 0 _BOOST_COMPILER_VERSION_MAJOR)


### PR DESCRIPTION
CMake bails out with an error message giving no clue what's going on, if variable CMAKE_CXX_COMPILER_VERSION is not set:

    CMake Error at /usr/lib/x86_64-linux-gnu/cmake/BoostDetectToolset-1.74.0.cmake:9 (string):
      string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
      command.
    Call Stack (most recent call first):
      /usr/lib/x86_64-linux-gnu/cmake/boost_thread-1.74.0/boost_thread-config.cmake:27 (include)
      /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake:141 (find_package)
      /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake:258 (boost_find_component)
      CMakeLists.txt:7 (find_package)

    -- Boost toolset is unknown (compiler  )

The added message still leads to a CMake error, but gives the user a better clue where to look for in her own project trying to find Boost.

Output afterwards:

    CMake Error at /usr/lib/x86_64-linux-gnu/cmake/BoostDetectToolset-1.74.0.cmake:6 (message):
      CMAKE_CXX_COMPILER_VERSION is not set!
    Call Stack (most recent call first):
      /usr/lib/x86_64-linux-gnu/cmake/boost_thread-1.74.0/boost_thread-config.cmake:27 (include)
      /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake:141 (find_package)
      /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake:258 (boost_find_component)
      CMakeLists.txt:7 (find_package)

    CMake Error at /usr/lib/x86_64-linux-gnu/cmake/BoostDetectToolset-1.74.0.cmake:8 (string):
      string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
      command.
    Call Stack (most recent call first):
      /usr/lib/x86_64-linux-gnu/cmake/boost_thread-1.74.0/boost_thread-config.cmake:27 (include)
      /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake:141 (find_package)
      /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake:258 (boost_find_component)
      CMakeLists.txt:7 (find_package)

    -- Boost toolset is unknown (compiler  )

Fixes: boostorg/boost_install#76