### PR TITLE
default install-package to Boost

### DIFF
--- a/boost-install.jam
+++ b/boost-install.jam
@@ -1023,15 +1023,15 @@ local rule install-cmake-config- ( install-or-stage : version : name : requireme
         local reqs = <version>$(version) <flags>library-type=$(library-type) <flags>name=$(name) ;
 
         r += [ make $(install-or-stage)/$(name)-config.cmake : $(name) : @boost-install%make-cmake-config : $(reqs) $(requirements) ] ;
-        r += [ install $(install-or-stage)-$(name)-config.cmake : $(install-or-stage)/$(name)-config.cmake : <location>$(loc) $(requirements) ] ;
+        r += [ install $(install-or-stage)-$(name)-config.cmake : $(install-or-stage)/$(name)-config.cmake : <location>$(loc) $(requirements) : <install-package>Boost ] ;
 
         r += [ make $(install-or-stage)/$(name)-config-version.cmake : $(name) : @boost-install%make-cmake-config-version : $(reqs) $(requirements) ] ;
-        r += [ install $(install-or-stage)-$(name)-config-version.cmake : $(install-or-stage)/$(name)-config-version.cmake : <location>$(loc) $(requirements) ] ;
+        r += [ install $(install-or-stage)-$(name)-config-version.cmake : $(install-or-stage)/$(name)-config-version.cmake : <location>$(loc) $(requirements) : <install-package>Boost ] ;
 
         if $(library-type) != INTERFACE
         {
             r += [ generate $(install-or-stage)/$(name)-variant.cmake : $(name) : <generating-rule>@boost-install%generate-cmake-variant $(reqs) ] ;
-            r += [ install $(install-or-stage)-$(name)-config-variant.cmake : $(install-or-stage)/$(name)-variant.cmake : <location>$(loc) $(requirements) ] ;
+            r += [ install $(install-or-stage)-$(name)-config-variant.cmake : $(install-or-stage)/$(name)-variant.cmake : <location>$(loc) $(requirements) : <install-package>Boost ] ;
         }
     }
     else
@@ -1083,19 +1083,19 @@ rule install-or-stage-cmake-config ( name * : install-or-stage )
         local boost-install-dir = [ modules.binding $(__name__) ] ;
         boost-install-dir = $(boost-install-dir:D) ;
 
-        install $(install-or-stage)-detect-toolset : $(boost-install-dir)/BoostDetectToolset.cmake : <location>(cmakedir) <name>BoostDetectToolset-$(BOOST_VERSION).cmake $(reqs) ;
+        install $(install-or-stage)-detect-toolset : $(boost-install-dir)/BoostDetectToolset.cmake : <location>(cmakedir) <name>BoostDetectToolset-$(BOOST_VERSION).cmake $(reqs) : <install-package>Boost ;
         $(p).mark-target-as-explicit $(install-or-stage)-detect-toolset ;
 
         # Target install/stage-boost-config
 
-        install $(install-or-stage)-boost-config : $(boost-install-dir)/BoostConfig.cmake : <location>(cmakedir)/Boost-$(BOOST_VERSION) $(reqs) ;
+        install $(install-or-stage)-boost-config : $(boost-install-dir)/BoostConfig.cmake : <location>(cmakedir)/Boost-$(BOOST_VERSION) $(reqs) : <install-package>Boost ;
         $(p).mark-target-as-explicit $(install-or-stage)-boost-config ;
 
         # Target install/stage-boost-config-version
 
         project.load [ path.make $(boost-install-dir) ] ;
 
-        install $(install-or-stage)-boost-config-version : /boost/boost_install//BoostConfigVersion.cmake : <location>(cmakedir)/Boost-$(BOOST_VERSION) $(reqs) ;
+        install $(install-or-stage)-boost-config-version : /boost/boost_install//BoostConfigVersion.cmake : <location>(cmakedir)/Boost-$(BOOST_VERSION) $(reqs) : <install-package>Boost ;
         $(p).mark-target-as-explicit $(install-or-stage)-boost-config-version ;
 
         # Target install/stage-cmake-config
@@ -1257,28 +1257,28 @@ rule boost-install ( libraries * )
 
     if ! [ $(p).has-alternative-for-target install ]
     {
-        install install-libraries-static : $(libraries) : <location>(libdir) <install-dependencies>on <install-type>STATIC_LIB ;
+        install install-libraries-static : $(libraries) : <location>(libdir) <install-dependencies>on <install-type>STATIC_LIB : <install-package>Boost ;
         $(p).mark-target-as-explicit install-libraries-static ;
 
         alias install-libraries-shared : install-libraries-shared- ;
         alias install-libraries-shared : install-libraries-shared-cygwin : <target-os>cygwin ;
         $(p).mark-target-as-explicit install-libraries-shared ;
 
-        install install-libraries-shared- : $(libraries) : <location>(libdir) <install-type>SHARED_LIB <install-type>PDB <install-dependencies>on <install-no-version-symlinks>on ;
+        install install-libraries-shared- : $(libraries) : <location>(libdir) <install-type>SHARED_LIB <install-type>PDB <install-dependencies>on <install-no-version-symlinks>on : <install-package>Boost ;
         $(p).mark-target-as-explicit install-libraries-shared- ;
 
-        install install-libraries-shared-cygwin : $(libraries) : <location>(bindir) <install-type>SHARED_LIB <install-type>PDB <install-dependencies>on <install-no-version-symlinks>on ;
+        install install-libraries-shared-cygwin : $(libraries) : <location>(bindir) <install-type>SHARED_LIB <install-type>PDB <install-dependencies>on <install-no-version-symlinks>on : <install-package>Boost ;
         $(p).mark-target-as-explicit install-libraries-shared-cygwin ;
 
-        install install-unprefixed-static : $(unprefixed) : <install-type>STATIC_LIB <conditional>@boost-install%install-subdir ;
+        install install-unprefixed-static : $(unprefixed) : <install-type>STATIC_LIB <conditional>@boost-install%install-subdir : <install-package>Boost ;
         $(p).mark-target-as-explicit install-unprefixed-static ;
 
-        install install-unprefixed-shared : $(unprefixed) : <install-type>SHARED_LIB <install-no-version-symlinks>on <conditional>@boost-install%install-subdir ;
+        install install-unprefixed-shared : $(unprefixed) : <install-type>SHARED_LIB <install-no-version-symlinks>on <conditional>@boost-install%install-subdir : <install-package>Boost ;
         $(p).mark-target-as-explicit install-unprefixed-shared ;
 
         install-cmake-config $(libraries) ;
 
-        generate install-dependencies : $(libraries) : <generating-rule>@boost-install%generate-dependencies <name>install ;
+        generate install-dependencies : $(libraries) : <generating-rule>@boost-install%generate-dependencies <name>install : <install-package>Boost ;
         $(p).mark-target-as-explicit install-dependencies ;
 
         alias install : install-libraries-static install-libraries-shared install-unprefixed-static install-unprefixed-shared install-cmake-config install-dependencies ;
@@ -1294,19 +1294,19 @@ rule boost-install ( libraries * )
 
         stage-cmake-config $(libraries) ;
 
-        install stage-libraries-static : $(libraries) : <location>(libdir) $(reqs) <install-dependencies>on <install-type>STATIC_LIB ;
+        install stage-libraries-static : $(libraries) : <location>(libdir) $(reqs) <install-dependencies>on <install-type>STATIC_LIB : <install-package>Boost ;
         $(p).mark-target-as-explicit stage-libraries-static ;
 
-        install stage-libraries-shared : $(libraries) : <location>(libdir) $(reqs) <install-dependencies>on <install-type>SHARED_LIB <install-type>PDB <install-no-version-symlinks>on ;
+        install stage-libraries-shared : $(libraries) : <location>(libdir) $(reqs) <install-dependencies>on <install-type>SHARED_LIB <install-type>PDB <install-no-version-symlinks>on : <install-package>Boost ;
         $(p).mark-target-as-explicit stage-libraries-shared ;
 
-        install stage-unprefixed-static : $(unprefixed) : <install-type>STATIC_LIB $(reqs) <conditional>@boost-install%install-subdir ;
+        install stage-unprefixed-static : $(unprefixed) : <install-type>STATIC_LIB $(reqs) <conditional>@boost-install%install-subdir : <install-package>Boost ;
         $(p).mark-target-as-explicit stage-unprefixed-static ;
 
-        install stage-unprefixed-shared : $(unprefixed) : <install-type>SHARED_LIB $(reqs) <install-type>PDB <install-no-version-symlinks>on <conditional>@boost-install%install-subdir ;
+        install stage-unprefixed-shared : $(unprefixed) : <install-type>SHARED_LIB $(reqs) <install-type>PDB <install-no-version-symlinks>on <conditional>@boost-install%install-subdir : <install-package>Boost ;
         $(p).mark-target-as-explicit stage-unprefixed-shared ;
 
-        generate stage-dependencies : $(libraries) : <generating-rule>@boost-install%generate-dependencies <name>stage ;
+        generate stage-dependencies : $(libraries) : <generating-rule>@boost-install%generate-dependencies <name>stage : <install-package>Boost ;
         $(p).mark-target-as-explicit stage-dependencies ;
 
         alias stage : stage-libraries-static stage-libraries-shared stage-unprefixed-static stage-unprefixed-shared stage-cmake-config stage-dependencies ;


### PR DESCRIPTION
`<install-prefix>` on Windows defaults to `C:\<install-package>`. `<install-package>` defaults to project's id if it has one, otherwise to the first id of an ancestor project. Before modular changes this resulted in libs/Jamfile inheriting project id of boost root (boost) and default installation prefix on Windows was `C:\boost`. But with modular changes library projects have their ids, and install into `C:\<lib>` instead. This change tells projects that by default they should install to `C:\Boost`.